### PR TITLE
Add lack props for IconButton API

### DIFF
--- a/src/gen/MaterialUI/IconButton.purs
+++ b/src/gen/MaterialUI/IconButton.purs
@@ -22,6 +22,14 @@ type IconButtonPropsO r = (
   ), 
   disabled :: Boolean, 
   disableRipple :: Boolean, 
+  edge :: OneOf (
+    typed :: StringConst "start",
+    typed :: StringConst "end"
+  ),
+  size :: OneOf (
+    typed :: StringConst "small",
+    typed :: StringConst "medium"
+  ),
   defaultChecked :: Boolean, 
   defaultValue :: OneOf (
     typed :: String, 


### PR DESCRIPTION
Hello maintainer,

I think we need these two props, "edge" and "size".

For your information: https://material-ui.com/api/icon-button/#props